### PR TITLE
Clarify bit order in kchal_send_fb

### DIFF
--- a/8bkc-components/8bkc-hal/include/8bkc-hal.h
+++ b/8bkc-components/8bkc-hal/include/8bkc-hal.h
@@ -86,8 +86,8 @@ void kchal_wait_keys_released();
  * @brief Send framebuffer to display
  *
  * @param fb Pointer to KC_SCREEN_W*KC_SCREEN_H (80x64) 16-bit values. The 16-bit values
- *           are defined as RRRRRGGGGGGBBBBB, BUT with the two bytes swapped, so
- *           GGGBBBBB RRRRRRGGGG.
+ *           are defined in 5-6-5 RGB format (RRRRRGGG:GGGBBBBB), BUT with the two bytes swapped,
+ *           so GGGBBBBB:RRRRRGGG.
  *
  * @note The kchal_fbval_rgb inline function provides an easy way to calculate pixel values
  *       starting from 8-bit RGB values.


### PR DESCRIPTION
Previous description showed 17 bits of data in the byte-swapped version of the pixels