### PR TITLE
add battery icon to powerbutton menu

### DIFF
--- a/8bkc-components/gui-util/8bkcgui-widgets.c
+++ b/8bkc-components/gui-util/8bkcgui-widgets.c
@@ -268,3 +268,21 @@ int kcugui_menu(kcugui_menuitem_t *menu, char *desc, kcugui_menu_cb_t cb, void *
 		} while (prKeys==0);
 	}
 }
+
+void kcugui_drawBatteryIcon() {
+	// draw outer battery frame and fill it with black
+	UG_DrawFrame(KC_SCREEN_W-17, 0, KC_SCREEN_W-3, 6, C_WHITE);
+	UG_FillFrame(KC_SCREEN_W-16, 1, KC_SCREEN_W-4, 5, C_BLACK);
+	// draw the positive contact
+	UG_DrawFrame(KC_SCREEN_W-2, 2, KC_SCREEN_W-1, 4, C_WHITE);
+
+	// collect battery info and select appropriate filler color
+	int b = kchal_get_bat_pct();
+	UG_COLOR batColor;
+	if (b < 20) batColor = C_RED;
+	else if (b < 50) batColor = C_GOLD;
+	else batColor = C_LIME;
+
+	// fill in battery, relative to battery SOC
+	UG_FillFrame(KC_SCREEN_W-16, 1, KC_SCREEN_W-4-(((100-b)*12)/100), 5, batColor);
+}

--- a/8bkc-components/gui-util/8bkcgui-widgets.h
+++ b/8bkc-components/gui-util/8bkcgui-widgets.h
@@ -137,6 +137,13 @@ typedef int (*kcugui_menu_cb_t)(int button, char **desc, kcugui_menuitem_t **men
  */
 int kcugui_menu(kcugui_menuitem_t *menu, char *desc, kcugui_menu_cb_t cb, void *usrptr);
 
+/**
+ * @brief Draws battery state-of-charge icon
+ * 
+ * Shows a small battery icon in the top-right, indicate the current battery remaining.
+ */
+void kcugui_drawBatteryIcon();
+
 #ifdef __cplusplus
 }
 #endif

--- a/8bkc-components/powerbtn_menu/powerbtn_menu.c
+++ b/8bkc-components/powerbtn_menu/powerbtn_menu.c
@@ -2,6 +2,8 @@
 #include <stdio.h>
 #include <string.h>
 #include "8bkc-hal.h"
+#include "ugui.h"
+#include "8bkcgui-widgets.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -172,6 +174,8 @@ int powerbtn_menu_show(uint16_t *fb) {
 			renderGfx(fb, 14, 25+16, 14, 130, (v*60)/256, 4);
 		}
 		
+		kcugui_drawBatteryIcon();
+
 		if (doRefresh) {
 			kchal_send_fb(fb);
 		}


### PR DESCRIPTION
Adds a tiny battery icon to the powerbutton menu.

@Spritetm are there concerns about importing ugui and widgets here, to maximize resources available to the other apps?