### PR TITLE
Flip powerbutton menu up/down keys

### DIFF
--- a/8bkc-components/powerbtn_menu/powerbtn_menu.c
+++ b/8bkc-components/powerbtn_menu/powerbtn_menu.c
@@ -86,12 +86,12 @@ int powerbtn_menu_show(uint16_t *fb) {
 		//Filter out only newly pressed buttons
 		io=(oldIo^newIo)&newIo;
 		oldIo=newIo;
-		if (io&KC_BTN_UP && !scroll) {
+		if (io&KC_BTN_DOWN && !scroll) {
 			menuItem++;
 			if (menuItem>=SCN_COUNT) menuItem=0;
 			scroll=-SCROLLSPD;
 		}
-		if (io&KC_BTN_DOWN && !scroll) {
+		if (io&KC_BTN_UP && !scroll) {
 			menuItem--;
 			if (menuItem<0) menuItem=SCN_COUNT-1;
 			scroll=SCROLLSPD;


### PR DESCRIPTION
Right now, the power button menu up/down keys function similar to a "swipe" command for touchscreen devices.  Pressing up "swipes" the menu up and away, showing the menu item below.

For this type of input, I'd expect pressing up to show the above item, not the below item.

Yes, this is minor and nitpicky.  Totally understand if others don't agree with this preference! :)